### PR TITLE
Replacement of the default Wire lib to fix hanging I2C communication 

### DIFF
--- a/I2C_CAN_Firmware.ino
+++ b/I2C_CAN_Firmware.ino
@@ -25,14 +25,14 @@
 
 #include <mcp_can.h>
 #include <SPI.h>
-#include <Wire.h>
+#include <SBWire.h> // Replaces standard Wire.h library
 #include <EEPROM.h>
 #include "I2C_CAN_dfs.h"
 
-#define  MAX_RECV_CAN_LEN       8          // BUF FOR CAN FRAME RECVING
+#define  MAX_RECV_CAN_LEN       16          // BUF FOR CAN FRAME RECVING (changed from 8 to 16 to be inline with the longan documentation)
 #define  EEPADDR_TESTMODE       99
 
-unsigned char can_frame_dta[MAX_RECV_CAN_LEN][16];
+unsigned char can_frame_dta[MAX_RECV_CAN_LEN][16]; // Buffer allows for 16 received can messages 
 int cnt_can_frame_dta       = 0;
 int index_can_frame_dta     = 0;
 int index_can_frame_read    = 0;
@@ -43,6 +43,7 @@ MCP_CAN CAN(SPI_CS_PIN);                                    // Set CS pin
 
 #define LEDON()     digitalWrite(3, HIGH)
 #define LEDOFF()    digitalWrite(3, LOW)
+#define LEDTOGGLE() digitalWrite(3, 1 - digitalRead(3))
 
 unsigned char i2c_get_len = 0;
 unsigned char i2c_dta[20];
@@ -70,9 +71,9 @@ void blinkTestMode()
     static unsigned long timer_s = millis();
     if(millis()-timer_s < 100)return;
     timer_s = millis();
-    
+
   
-    digitalWrite(3, 1-digitalRead(3));
+    LEDTOGGLE();
 }
 
 void testModeCANSend()
@@ -145,14 +146,14 @@ PINTEST:
     {
         
         delay(500);
-        digitalWrite(3, 1-digitalRead(3));
+        LEDTOGGLE();
     }
 
     EEPROM.write(EEPADDR_TESTMODE, 0xAB);
     while(1)
     {
         delay(50);
-        digitalWrite(3, 1-digitalRead(3));
+        LEDTOGGLE();
         testModeCANSend();
     }
 
@@ -170,7 +171,7 @@ void setup()
     
     for(int i=0; i<20; i++)
     {
-        digitalWrite(3, 1-digitalRead(3));
+        LEDTOGGLE();
         delay(20);
     }
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Frimware of I2C CAN Bus Module
+# Firmware of I2C CAN Bus Module
 
 [![Actions Status](https://github.com/arduino/arduino-cli-example/workflows/test/badge.svg)](https://github.com/arduino/arduino-cli-example/actions)
 [![Spell Check](https://github.com/arduino/compile-sketches/workflows/Spell%20Check/badge.svg)](https://github.com/arduino/compile-sketches/actions?workflow=Spell+Check)
@@ -6,20 +6,24 @@
 
 Firmware of I2C CAN Bus Module.
 
-## Installation an Arduino library
+## Installation Arduino libraries
 
-Please install the [Arduino CAN BUS MCP2515 Library](https://github.com/Longan-Labs/Aruino_CAN_BUS_MCP2515).
-Then you can compile the firmware.
+This project requires two libraries:
+- **[Arduino CAN BUS MCP2515 Library](https://github.com/Longan-Labs/Aruino_CAN_BUS_MCP2515)**. Driver for the MPC2515 CAN Bus transceiver.
+- **[SBWire](https://github.com/freespace/SBWire)**. Replacement for the default Arduino Wire (i<sup>2</sup>c) library with basic timeouts to fix the board from occasionally not correctly responding to i<sup>2</sup>c messages. See this [post](https://www.fpaynter.com//2018/08/known-defect-in-arduino-i2c-code-causes-hangup-problems/).
 
-1. [Download the library](https://github.com/Longan-Labs/Aruino_CAN_BUS_MCP2515/archive/refs/heads/master.zip)
-2. Extract the zip file
-3. In the Arduino IDe, navigate to Sketch > Include Library > Add .ZIP Library
+Please install the both libraries first before compiling this sketch. 
+To install a library
+
+1. Download both libraries ([Arduino CAN BUS MCP2515 Library](https://github.com/Longan-Labs/Aruino_CAN_BUS_MCP2515/archive/refs/heads/master.zip) and the [SBWire](https://github.com/freespace/SBWire/archive/refs/heads/master.zip)).
+2. In the Arduino IDE, navigate to Sketch > Include Library > Add .ZIP Library, select the just downloaded zip file.
+3. Repeat for the second library. 
 
 ## Get a Dev Board
 
-If you need a Dev board, plese try,
+If you need a Dev board, please try,
 
-- [I2C CAN Bus Module](https://www.longan-labs.cc/1030017.html)
+- [I2C CAN Bus Module](https://www.longan-labs.cc/1030017.html) 
 
 You can get others CAN Dev board below,
 
@@ -58,3 +62,49 @@ SOFTWARE.
 ## Contact us
 
 If you have any question, please feel free to contact [support@longan-labs.cc](support@longan-labs.cc)
+
+## I<sup>2</sup>C Registers
+
+The device default I<sup>2</sup>C slave address is 0x25 but can be changed by writing to address 1. Note that the new address is stored inside the internal EEPROM of the chip, and therefore changes in the bus address will remain after power loss. 
+
+The following table contains the various registers that are available on the i2c interface of the CAN Module.
+
+| Address | Name   | Length   | Type | Default Value | Description                                   |
+| ------- | ------ | -------- | ---- | ------------- | --------------------------------------------- |
+| 0x01    | Addr   | 1 Byte   | W    | 0x25          | I2C slave Address                             |
+| 0x02    | DNUM   | 1 Byte   | R    | 0             | No. of CAN frames in RX buffer (max 16)       |
+| 0x03    | BAUD   | 1 Byte   | W    | 16(500kb/s)   | Set the CAN baudrate                          |
+| 0x04    | Errors | 3 Bytes  | R    | 0             | B0: Error flags, B1: TX errors, B2: Rx errors |
+| 0x30    | Send   | 16 Bytes | W    | -             | Send CAN frame                                |
+| 0x40    | Recv   | 16 Bytes | R    | -             | Read CAN frame from Recv buffer               |
+| 0x60    | Mask0  | 5 Bytes  | W/R  | 0             | Mask 0                                        |
+| 0x65    | Mask1  | 5 Bytes  | W/R  | 0             | Mask 1                                        |
+| 0x70    | Filt0  | 5 Bytes  | W/R  | 0             | Filter 0                                      |
+| 0x80    | Filt1  | 5 Bytes  | W/R  | 0             | Filter 1                                      |
+| 0x90    | Filt2  | 5 Bytes  | W/R  | 0             | Filter 2                                      |
+| 0xA0    | Filt3  | 5 Bytes  | W/R  | 0             | Filter 3                                      |
+| 0xB0    | Filt4  | 5 Bytes  | W/R  | 0             | Filter 4                                      |
+| 0xC0    | Filt5  | 5 Bytes  | W/R  | 0             | Filter 5                                      |
+
+### 0x03 - CAN baudrates
+
+| Value  | CAN Baudrate (kb/s) |
+| ------ | ------------------- |
+| 1      | 5                   |
+| 2      | 10                  |
+| 3      | 20                  |
+| 4      | 25                  |
+| 5      | 31.2                |
+| 6      | 33                  |
+| 7      | 40                  |
+| 8      | 50                  |
+| 9      | 80                  |
+| 10     | 83.3                |
+| 11     | 95                  |
+| 12     | 100                 |
+| 13     | 125                 |
+| 14     | 200                 |
+| 15     | 250                 |
+| **16** | **500** (default)   |
+| 17     | 666                 |
+| 18     | 1000                |


### PR DESCRIPTION
In this pull request I've replaced the default Arduino Wire library (included in your [longan-boards](https://github.com/Longan-Labs/Longan-Board) package) with the [SBWire](https://github.com/freespace/SBWire) lib from freespace. 

I did this because I had issues with the CAN board sometimes not responding to I2C messages which was caused by some while loops inside the wire lib that it gets stuck in while sending/receiving data. This issue disappeared when I replaced the Wire lib with the SBWire lib. I also added the I2C documentation to the readme for easy access. 

